### PR TITLE
Bucket B: per-coin data safety (missing coins + divide-by-zero)

### DIFF
--- a/CryptoPriceTracker.py
+++ b/CryptoPriceTracker.py
@@ -69,6 +69,8 @@ def main(holdings=None, url=API_URL):
             print(f"  (skipped {key}: invalid holding total <= 0)", file=sys.stderr)
             continue
 
+        # A coin may report a price but omit 24h change; show the row anyway,
+        # treating the missing change as 0.0% rather than skipping it.
         change = coin.get('usd_24h_change', 0.0)
         print("%20s     %8.2f     %4d      %5.2f" % (
             key, profit, value['cost'], change))

--- a/CryptoPriceTracker.py
+++ b/CryptoPriceTracker.py
@@ -35,6 +35,16 @@ def fetch_prices(url, timeout=10):
     return response.json()
 
 
+def compute_profit(holding, price):
+    """Return total profit for a holding at the given USD price, or None when
+    the holding total is non-positive (avoids divide-by-zero on user input)."""
+    total = holding['total']
+    if total <= 0:
+        return None
+    avgCost = holding['cost'] / total
+    return (price - avgCost) * total
+
+
 def main(holdings=None, url=API_URL):
     if holdings is None:
         holdings = originalHoldings
@@ -49,12 +59,19 @@ def main(holdings=None, url=API_URL):
     print("---------------------   ----------   ------   ---------")
 
     for key, value in holdings.items():
-        avgCost = value['cost'] / value['total']
-        profitPerCoin = priceData[key]['usd'] - avgCost
-        profit = profitPerCoin * value['total']
+        coin = priceData.get(key)
+        if coin is None or 'usd' not in coin:
+            print(f"  (skipped {key}: no price data returned)", file=sys.stderr)
+            continue
 
+        profit = compute_profit(value, coin['usd'])
+        if profit is None:
+            print(f"  (skipped {key}: invalid holding total <= 0)", file=sys.stderr)
+            continue
+
+        change = coin.get('usd_24h_change', 0.0)
         print("%20s     %8.2f     %4d      %5.2f" % (
-            key, profit, value['cost'], priceData[key]['usd_24h_change']))
+            key, profit, value['cost'], change))
 
 
 if __name__ == "__main__":

--- a/tests/test_crypto_price_tracker.py
+++ b/tests/test_crypto_price_tracker.py
@@ -33,3 +33,45 @@ def test_main_exits_1_on_network_error(capsys):
     assert exc.value.code == 1
     err = capsys.readouterr().err
     assert "Failed to fetch prices" in err
+
+
+def test_compute_profit_single_coin():
+    # avg cost = 200/1 = 200; price 300 -> profit 100
+    assert cpt.compute_profit({"total": 1, "cost": 200}, 300) == 100
+
+
+def test_compute_profit_multiple_coins():
+    # avg cost = 200/2 = 100; price 150 -> per-coin 50 * 2 = 100
+    assert cpt.compute_profit({"total": 2, "cost": 200}, 150) == 100
+
+
+def test_compute_profit_zero_total_returns_none():
+    assert cpt.compute_profit({"total": 0, "cost": 20}, 50) is None
+
+
+def test_compute_profit_negative_total_returns_none():
+    assert cpt.compute_profit({"total": -1, "cost": 20}, 50) is None
+
+
+def test_main_skips_missing_coin_and_prints_present_one(capsys):
+    holdings = {
+        "bitcoin": {"total": 1, "cost": 200},
+        "mirror-protocol": {"total": 1, "cost": 20},  # absent from payload
+    }
+    payload = {"bitcoin": {"usd": 50000, "usd_24h_change": 1.5}}
+    with patch("CryptoPriceTracker.fetch_prices", return_value=payload):
+        cpt.main(holdings=holdings)
+    captured = capsys.readouterr()
+    assert "bitcoin" in captured.out          # present coin -> stdout table
+    assert "mirror-protocol" not in captured.out  # missing coin not in table
+    assert "mirror-protocol" in captured.err  # skip notice on stderr
+
+
+def test_main_skips_zero_total_holding(capsys):
+    holdings = {"bitcoin": {"total": 0, "cost": 200}}
+    payload = {"bitcoin": {"usd": 50000, "usd_24h_change": 1.5}}
+    with patch("CryptoPriceTracker.fetch_prices", return_value=payload):
+        cpt.main(holdings=holdings)
+    captured = capsys.readouterr()
+    assert "bitcoin" not in captured.out      # not in the table
+    assert "bitcoin" in captured.err          # skip notice on stderr

--- a/tests/test_crypto_price_tracker.py
+++ b/tests/test_crypto_price_tracker.py
@@ -62,6 +62,7 @@ def test_main_skips_missing_coin_and_prints_present_one(capsys):
     with patch("CryptoPriceTracker.fetch_prices", return_value=payload):
         cpt.main(holdings=holdings)
     captured = capsys.readouterr()
+    assert "Coin" in captured.out             # table header still printed
     assert "bitcoin" in captured.out          # present coin -> stdout table
     assert "mirror-protocol" not in captured.out  # missing coin not in table
     assert "mirror-protocol" in captured.err  # skip notice on stderr


### PR DESCRIPTION
## What

Bucket B of the crypto tracker hardening plan. Makes the profit loop resilient to bad/partial data on top of Bucket A's refactor.

- Add a pure `compute_profit(holding, price)` helper that returns `None` when a holding's `total <= 0`, eliminating the `ZeroDivisionError` on user-edited holdings.
- Rewrite the `main` loop to look up coins with `priceData.get(key)` and skip any coin that is absent or missing a `usd` price — printing a `(skipped ...)` notice to **stderr** instead of crashing with `KeyError` (e.g. when CoinGecko delists a coin like `mirror-protocol`).
- Read `usd_24h_change` defensively with `.get(..., 0.0)` so a coin with a price but no change figure still renders. (Documented as intentional.)
- Diagnostics go to stderr; the stdout table stays clean and pipeable.

## Testing

`python3 -m pytest` → 9 passed (3 from Bucket A + 6 new: 4 unit tests for `compute_profit`, 2 capsys integration tests for the skip-and-still-print behavior, including a header assertion).