### PR TITLE
Follow-up: skip coins with a null/missing usd price

### DIFF
--- a/CryptoPriceTracker.py
+++ b/CryptoPriceTracker.py
@@ -60,7 +60,7 @@ def main(holdings=None, url=API_URL):
 
     for key, value in holdings.items():
         coin = priceData.get(key)
-        if coin is None or 'usd' not in coin:
+        if coin is None or coin.get('usd') is None:
             print(f"  (skipped {key}: no price data returned)", file=sys.stderr)
             continue
 

--- a/tests/test_crypto_price_tracker.py
+++ b/tests/test_crypto_price_tracker.py
@@ -76,3 +76,23 @@ def test_main_skips_zero_total_holding(capsys):
     captured = capsys.readouterr()
     assert "bitcoin" not in captured.out      # not in the table
     assert "bitcoin" in captured.err          # skip notice on stderr
+
+
+def test_main_skips_coin_present_but_missing_usd_key(capsys):
+    holdings = {"bitcoin": {"total": 1, "cost": 200}}
+    payload = {"bitcoin": {"usd_24h_change": 1.5}}  # 'usd' key absent
+    with patch("CryptoPriceTracker.fetch_prices", return_value=payload):
+        cpt.main(holdings=holdings)
+    captured = capsys.readouterr()
+    assert "bitcoin" not in captured.out
+    assert "bitcoin" in captured.err
+
+
+def test_main_skips_coin_with_null_usd_price(capsys):
+    holdings = {"bitcoin": {"total": 1, "cost": 200}}
+    payload = {"bitcoin": {"usd": None, "usd_24h_change": 1.5}}  # 'usd' is None
+    with patch("CryptoPriceTracker.fetch_prices", return_value=payload):
+        cpt.main(holdings=holdings)
+    captured = capsys.readouterr()
+    assert "bitcoin" not in captured.out
+    assert "bitcoin" in captured.err


### PR DESCRIPTION
## What

Follow-up from the final review of the hardening effort. Closes a latent `TypeError`.

The `main` loop previously skipped a coin only when it was absent or the `usd` key was missing. If CoinGecko returned the key with a **null** value (`{"bitcoin": {"usd": null, ...}}`) — possible under degraded/rate-limited service — the loop proceeded and called `compute_profit(value, None)`, raising `TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'`.

- Change the skip guard from `'usd' not in coin` to `coin.get('usd') is None`, which catches both a missing key and a null value. No output change for valid data.
- Add 2 tests: coin present but missing `usd` key, and coin present with `usd: None`.

## Testing

`python3 -m pytest` → 11 passed (9 prior + 2 new).