### PR TITLE
Follow-up: render fractional holding costs correctly

### DIFF
--- a/CryptoPriceTracker.py
+++ b/CryptoPriceTracker.py
@@ -72,7 +72,7 @@ def main(holdings=None, url=API_URL):
         # A coin may report a price but omit 24h change; show the row anyway,
         # treating the missing change as 0.0% rather than skipping it.
         change = coin.get('usd_24h_change', 0.0)
-        print("%20s     %8.2f     %4d      %5.2f" % (
+        print("%20s     %8.2f     %8.2f      %5.2f" % (
             key, profit, value['cost'], change))
 
 

--- a/tests/test_crypto_price_tracker.py
+++ b/tests/test_crypto_price_tracker.py
@@ -96,3 +96,14 @@ def test_main_skips_coin_with_null_usd_price(capsys):
     captured = capsys.readouterr()
     assert "bitcoin" not in captured.out
     assert "bitcoin" in captured.err
+
+
+def test_main_handles_fractional_cost(capsys):
+    holdings = {"bitcoin": {"total": 1, "cost": 19.99}}
+    payload = {"bitcoin": {"usd": 50000, "usd_24h_change": 1.5}}
+    with patch("CryptoPriceTracker.fetch_prices", return_value=payload):
+        cpt.main(holdings=holdings)
+    captured = capsys.readouterr()
+    assert "bitcoin" in captured.out      # row printed, no crash
+    assert "19.99" in captured.out        # fractional cost rendered
+    assert "bitcoin" not in captured.err  # not skipped


### PR DESCRIPTION
## What

Follow-up from the final review. The cost column used the integer format `%4d`. With a fractional cost like `"cost": 19.99`, that silently truncates to `19` on Python 3.14 (a wrong displayed value), and raises `TypeError` on some other versions.

- Change the cost field in the row format from `%4d` to `%8.2f` so fractional costs render accurately (e.g. `19.99`).
- Add a test that a fractional cost prints the real value and isn't skipped or truncated.

Note: this slightly widens the Cost column in the output table (now `   19.99` rather than `  20`), which is the intended trade-off for accurate cost display.

## Testing

`python3 -m pytest` → 12 passed (11 prior + 1 new). `pyflakes` clean.